### PR TITLE
Complex env vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='vcst',
-      version="0.0.4",
+      version="0.0.5",
       description="VUnit & cocotb smashed Together",
       author="James Price",
       author_email="jpwice100@gmail.com",

--- a/vcst/monkey_patching/rivierapro.py
+++ b/vcst/monkey_patching/rivierapro.py
@@ -19,11 +19,11 @@ def set_env_var(self, env):
         value = env[var].replace('{', '\\{').replace('}', '\\}')
         if ';' in value:
             process.writeline(f'''puts "+++ Skipping \\"{var}\\" (to avoid ';') +++"''')
+        elif '\n' in value:
+            process.writeline(f'''puts "+++ Skipping \\"{var}\\" (to avoid '\\n') +++"''')
+            #process.writeline(f'''set ::env({var}) [lines {{{value}}}]''')
         else:
-            if '\n' in value:
-                process.writeline(f'''set ::env({var}) [lines {{{value}}}]''')
-            else:
-                process.writeline(f'''set ::env({var}) {{{value}}}''')
+            process.writeline(f'''set ::env({var}) {{{value}}}''')
         #set_env_str = f"set ::env({var}) [subst -nobackslashes -nocommand -novariables {{ {value} }} ]"
         #process.writeline(f'''puts "{var}=[set ::env({var})]"''')
         #process.writeline('puts "------------------"')

--- a/vcst/monkey_patching/rivierapro.py
+++ b/vcst/monkey_patching/rivierapro.py
@@ -21,7 +21,7 @@ def set_env_var(self, env):
             process.writeline(f'''puts "+++ Skipping \\"{var}\\" (to avoid ';') +++"''')
         else:
             if '\n' in value:
-                process.writeline(f'''set ::env({var}) [lines {{{value}}}]]''')
+                process.writeline(f'''set ::env({var}) [lines {{{value}}}]''')
             else:
                 process.writeline(f'''set ::env({var}) {{{value}}}''')
         #set_env_str = f"set ::env({var}) [subst -nobackslashes -nocommand -novariables {{ {value} }} ]"

--- a/vcst/monkey_patching/rivierapro.py
+++ b/vcst/monkey_patching/rivierapro.py
@@ -8,17 +8,27 @@ from vunit.ostools import write_file, Process
 
 def set_env_var(self, env):
     process = self._process()
-    #process.writeline('puts "Updating Tcl script to copy environment variables into Tcl-land"')
+    process.writeline('puts "Updating Tcl script to copy environment variables into Tcl-land"')
+    # Ideas from: https://stackoverflow.com/questions/22629160/neatly-listing-values-in-multiple-lines
+    process.writeline("""proc lines {{lines}} {{ foreach item [uplevel [list subst -nobackslash -nocommand -novarialbes $lines] {{ lappend list $item }} return $list }}""")
+    #process.writeline('puts "------------------"')
     for var in env:
         # Tcl bounds using curly braces -- escape them then use a curly brace around the "value"
         # Note: this does not handle non-printable chars
         # Using subst call to escape: []$
-        value = env[var].replace('{', '\{').replace('}', '\}')
-        set_env_str = f"set ::env({var}) [subst -nobackslashes -nocommand -novariables {{ {value} }} ]"
-        process.writeline(set_env_str)
-        #process.writeline(f'puts "{var} = ${{::env({var})}}"')
+        value = env[var].replace('{', '\\{').replace('}', '\\}')
+        if ';' in value:
+            process.writeline(f'''puts "+++ Skipping \\"{var}\\" (to avoid ';') +++"''')
+        else:
+            if '\n' in value:
+                process.writeline(f'''set ::env({var}) [lines {{{value}}}]]''')
+            else:
+                process.writeline(f'''set ::env({var}) {{{value}}}''')
+        #set_env_str = f"set ::env({var}) [subst -nobackslashes -nocommand -novariables {{ {value} }} ]"
+        #process.writeline(f'''puts "{var}=[set ::env({var})]"''')
+        #process.writeline('puts "------------------"')
     #process.writeline('puts "Done copying the environment variables into Tcl-land"')
-
+        
 def rivierapro_run_batch_file(self, batch_file_name, gui=False, env=None):
     """
     Run a test bench in batch by invoking a new vsim process from the command line


### PR DESCRIPTION
Tried to handle env vars with lots of complexity, but in the end skipping them as only the simple ones are needed.

RedHat-isms in the env create headaches like:
```shell
# BASH_FUNC_scl%%=() {  if [ "$1" = "load" -o "$1" = "unload" ]; then
#  eval "module $@";
#  else
#  /usr/bin/scl "$@";
#  fi
# }
```