### PR TITLE
XML getchildren() function is deprecated

### DIFF
--- a/vcst/test/suites.py
+++ b/vcst/test/suites.py
@@ -141,7 +141,7 @@ class CocoTestRun(TestRun):
         tree = ET.parse(file_name)
         root = tree.getroot()
 
-        test_suites = root.getchildren()[0]
+        test_suites = list(root)[0]
         results_tests = []    
         for result in test_suites:
             if result.tag == "testcase":            


### PR DESCRIPTION
Per Python's documentation, xml.etree.ElementTree.Element.getchildren() function is deprecated and no longer exists in python 3.9 and up.
Guidance from the docs suggests using list(elem) instead.

Reference:
https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren