### PR TITLE
Added a new (optional) @vcst.test() decorator which adds support for test attributes inline in the test decorator

### DIFF
--- a/vcst/__init__.py
+++ b/vcst/__init__.py
@@ -1,2 +1,3 @@
 from vcst.ui import VCST
+from vcst.decorators import test  # supports either @vcst.test(...) or @vcst.decorators.test(...)
 import vcst.monkey_patching

--- a/vcst/decorators.py
+++ b/vcst/decorators.py
@@ -1,0 +1,15 @@
+from cocotb.decorators import test as cocotb_test
+
+class test(cocotb_test):
+    """
+    Subclass of cocotb.decorators.test (https://docs.cocotb.org/en/stable/_modules/cocotb/decorators.html) which
+    adds support for an "attributes" keyword argument.
+
+    Used as ``@vcst.test(..., attributes=['.long_running'])`` in lieu of ``@cocotb.test(...)``.
+    """
+    def __init__(self, *args, **kwargs):
+        self.attributes = []
+        if 'attributes' in kwargs:
+            self.attributes = kwargs['attributes']
+            del kwargs['attributes']  # don't pass attributes kwarg to cocotb's constructor - that would error
+        super().__init__(*args, **kwargs)

--- a/vcst/test/bench.py
+++ b/vcst/test/bench.py
@@ -5,8 +5,10 @@ import types
 from pathlib import Path
 from collections import OrderedDict
 from importlib.machinery import SourceFileLoader
+from dataclasses import dataclass
 
 from cocotb.decorators import test as Test
+from ..decorators import test as vcst_Test
 
 from vunit.test.bench import TestBench, TestConfigurationVisitor, FileLocation
 from vunit.configuration import ConfigurationVisitor, Configuration, DEFAULT_NAME
@@ -51,7 +53,11 @@ class CocoTestBench(TestBench):
         for obj_name in dir(cocotb_module):
             obj = getattr(cocotb_module, obj_name)
             if isinstance(obj, Test):
-                tests.append(CocoTest(obj.__name__, self.design_unit, cocotb_module, cocotb_module_location))
+                coco_test = CocoTest(obj.__name__, self.design_unit, cocotb_module, cocotb_module_location)
+                if isinstance(obj, vcst_Test):
+                    for attr in obj.attributes:
+                        coco_test.add_attribute(CocoTestAttribute(attr, None))
+                tests.append(coco_test)
 
         default_config = Configuration(DEFAULT_NAME, self.design_unit)                  
         self._test_cases = [
@@ -143,4 +149,8 @@ class CocoTestConfigurationVisitor(TestConfigurationVisitor):
             )        
 
 
+@dataclass
+class CocoTestAttribute:
+    name: str
+    value: str
 


### PR DESCRIPTION
Added a new (optional) @vcst.test() decorator which subclasses cocotb.test() but adds support for an attributes keyword, which takes a list of attributes - opting to use this new decorator allows test authors to put arbitrary attributes on their tests inline without prcoedural code, which then can be used with the --with-attribute and --without-attribute CLI switches to select different types of tests to run